### PR TITLE
config: Allow configs build from multiple envvars

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -14,6 +14,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
+import * as _ from 'lodash';
+
 import { Configuration, GenerateHaproxyConfig } from './generate-config';
 import { LoadJSONFile } from './utils';
 const capitano = require('capitano');
@@ -26,7 +28,7 @@ interface CommandOptions {
 }
 
 const help = () => {
-	console.log(`Usage: generate [COMMANDS] [OPTIONS]`);
+	console.log(`Usage: config [COMMANDS] [OPTIONS]`);
 	console.log('\nCommands:\n');
 
 	for (let command of capitano.state.commands) {
@@ -80,10 +82,24 @@ capitano.command({
 			commandOptions['output-config'] || '/usr/local/etc/haproxy/haproxy.cfg';
 		let processConfig;
 		if (envvar && (processConfig = process.env[envvar])) {
-			const config = JSON.parse(
-				Buffer.from(processConfig, 'base64').toString(),
-			);
-			return GenerateHaproxyConfig(config, outputConfig, outputCert);
+			// It's entirely possible the encoded HAProxy config is too large to fit
+			// in a single envvar (see MAX_ARG_STRLEN, which by default has a kernel
+			// argument limit of 128K). Because of this, we instead allow configs to
+			// be split into multiple chunked objects which are joined together.
+			// The subsequent envvars must be named `<prefix>_<x>` where <prefix>
+			// is the original `envvar` key, and <x> should be a number starting at
+			// '1' and incrementing for each extra config partial.
+			let finalConfig = {};
+			let configCounter = 1;
+			while (processConfig) {
+				_.assign(
+					finalConfig,
+					JSON.parse(Buffer.from(processConfig, 'base64').toString()),
+				);
+				processConfig = process.env[`${envvar}_${configCounter++}`];
+			}
+
+			return GenerateHaproxyConfig(finalConfig, outputConfig, outputCert);
 		} else if (envvar) {
 			throw new Error('Could not find environment variable: ' + envvar);
 		} else {

--- a/test/generate-config.spec.ts
+++ b/test/generate-config.spec.ts
@@ -17,6 +17,7 @@ import * as Bluebird from 'bluebird';
 import * as rootPath from 'app-root-path';
 import * as chai from 'chai';
 import * as chaiAsPromised from 'chai-as-promised';
+import { execSync } from 'child_process';
 import 'mocha';
 import * as temp from 'temp';
 
@@ -79,4 +80,35 @@ describe('HAProxy Configuration Generation', () => {
 			);
 		});
 	});
+
+	it('should generate a valid HAProxy config from a set of envvars', () => {
+		return Bluebird.fromCallback<string>(cb => {
+			return temp.mkdir('haproxy-tests', cb);
+		}).then(tempDir => {
+			const configOne =
+				'ewogICAgImZpcnN0IjogewogICAgICAgICJiYWNrZW5kIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAidXJsIjogImh0dHA6Ly9maXJzdDo4MCIsCiAgICAgICAgICAgICAgICAic2VydmVyIjogewogICAgICAgICAgICAgICAgICAgICJjaGVjayI6IG51bGwsCiAgICAgICAgICAgICAgICAgICAgInBvcnQiOiAiPHBvcnQ+IgogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgXSwKICAgICAgICAiZnJvbnRlbmQiOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJwcm90b2NvbCI6ICJodHRwIiwKICAgICAgICAgICAgICAgICJkb21haW4iOiAidGVzdC5kb21haW4iLAogICAgICAgICAgICAgICAgInN1YmRvbWFpbiI6ICJmaXJzdCIsCiAgICAgICAgICAgICAgICAicG9ydCI6ICI4MCIKICAgICAgICAgICAgfQogICAgICAgIF0KICAgIH0sCiAgICAic2Vjb25kIjogewogICAgICAgICJiYWNrZW5kIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAidXJsIjogImh0dHA6Ly9zZWNvbmQ6ODAiLAogICAgICAgICAgICAgICAgInNlcnZlciI6IHsKICAgICAgICAgICAgICAgICAgICAiY2hlY2siOiBudWxsLAogICAgICAgICAgICAgICAgICAgICJwb3J0IjogIjxwb3J0PiIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgImZyb250ZW5kIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAicHJvdG9jb2wiOiAiaHR0cCIsCiAgICAgICAgICAgICAgICAiZG9tYWluIjogInRlc3QuZG9tYWluIiwKICAgICAgICAgICAgICAgICJzdWJkb21haW4iOiAic2Vjb25kIiwKICAgICAgICAgICAgICAgICJwb3J0IjogIjgwIgogICAgICAgICAgICB9CiAgICAgICAgXQogICAgfQp9Cg==';
+			const configTwo =
+				'ewogICAgInRoaXJkIjogewogICAgICAgICJiYWNrZW5kIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAidXJsIjogImh0dHA6Ly90aGlyZDo4MCIsCiAgICAgICAgICAgICAgICAic2VydmVyIjogewogICAgICAgICAgICAgICAgICAgICJjaGVjayI6IG51bGwsCiAgICAgICAgICAgICAgICAgICAgInBvcnQiOiAiPHBvcnQ+IgogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgXSwKICAgICAgICAiZnJvbnRlbmQiOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJwcm90b2NvbCI6ICJodHRwIiwKICAgICAgICAgICAgICAgICJkb21haW4iOiAidGVzdC5kb21haW4iLAogICAgICAgICAgICAgICAgInN1YmRvbWFpbiI6ICJ0aGlyZCIsCiAgICAgICAgICAgICAgICAicG9ydCI6ICI4MCIKICAgICAgICAgICAgfQogICAgICAgIF0KICAgIH0sCiAgICAiZm91cnRoIjogewogICAgICAgICJiYWNrZW5kIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAidXJsIjogImh0dHA6Ly9mb3VydGg6ODAiLAogICAgICAgICAgICAgICAgInNlcnZlciI6IHsKICAgICAgICAgICAgICAgICAgICAiY2hlY2siOiBudWxsLAogICAgICAgICAgICAgICAgICAgICJwb3J0IjogIjxwb3J0PiIKICAgICAgICAgICAgICAgIH0KICAgICAgICAgICAgfQogICAgICAgIF0sCiAgICAgICAgImZyb250ZW5kIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAicHJvdG9jb2wiOiAiaHR0cCIsCiAgICAgICAgICAgICAgICAiZG9tYWluIjogInRlc3QuZG9tYWluIiwKICAgICAgICAgICAgICAgICJzdWJkb21haW4iOiAiZm91cnRoIiwKICAgICAgICAgICAgICAgICJwb3J0IjogIjgwIgogICAgICAgICAgICB9CiAgICAgICAgXQogICAgfQp9Cg==';
+			const configThree =
+				'ewogICAgImZpZnRoIjogewogICAgICAgICJiYWNrZW5kIjogWwogICAgICAgICAgICB7CiAgICAgICAgICAgICAgICAidXJsIjogImh0dHA6Ly9maWZ0aDo4MCIsCiAgICAgICAgICAgICAgICAic2VydmVyIjogewogICAgICAgICAgICAgICAgICAgICJjaGVjayI6IG51bGwsCiAgICAgICAgICAgICAgICAgICAgInBvcnQiOiAiPHBvcnQ+IgogICAgICAgICAgICAgICAgfQogICAgICAgICAgICB9CiAgICAgICAgXSwKICAgICAgICAiZnJvbnRlbmQiOiBbCiAgICAgICAgICAgIHsKICAgICAgICAgICAgICAgICJwcm90b2NvbCI6ICJodHRwIiwKICAgICAgICAgICAgICAgICJkb21haW4iOiAidGVzdC5kb21haW4iLAogICAgICAgICAgICAgICAgInN1YmRvbWFpbiI6ICJmaWZ0aCIsCiAgICAgICAgICAgICAgICAicG9ydCI6ICI4MCIKICAgICAgICAgICAgfQogICAgICAgIF0KICAgIH0KfQo=';
+
+			const command =
+				`TEST_CONFIG=${configOne} TEST_CONFIG_1=${configTwo} TEST_CONFIG_2=${configThree} ` +
+				`${process.cwd()}/bin/generate-config config -e TEST_CONFIG ` +
+				`-p ${tempDir}/chain.pem -c ${tempDir}/output`;
+
+			// A horrible sync is the simplest thing to do.
+			execSync(command);
+
+			return loadFiles([
+				`${tempDir}/output`,
+				`${rootPath}/test/outputs/envvar-output-config`,
+			]).then(files => {
+				const testConfigFile = files[0];
+				const refConfigFile = files[1];
+
+				testConfigFile.should.deep.equals(refConfigFile);
+			});
+		});
+	}).timeout(10000);
 });

--- a/test/outputs/envvar-output-config
+++ b/test/outputs/envvar-output-config
@@ -1,0 +1,58 @@
+global
+tune.ssl.default-dh-param 1024
+
+defaults
+timeout connect 5000
+timeout client 60000
+timeout server 60000
+
+frontend http_80_in
+mode http
+option forwardfor
+bind *:80
+reqadd X-Forwarded-Proto:\ http
+
+acl host_first_backend hdr_dom(host) -i first.test.domain
+use_backend first_backend if host_first_backend
+
+acl host_second_backend hdr_dom(host) -i second.test.domain
+use_backend second_backend if host_second_backend
+
+acl host_third_backend hdr_dom(host) -i third.test.domain
+use_backend third_backend if host_third_backend
+
+acl host_fourth_backend hdr_dom(host) -i fourth.test.domain
+use_backend fourth_backend if host_fourth_backend
+
+acl host_fifth_backend hdr_dom(host) -i fifth.test.domain
+use_backend fifth_backend if host_fifth_backend
+
+backend first_backend
+mode http
+option forwardfor
+balance roundrobin
+server first first:80 check port 80
+
+backend second_backend
+mode http
+option forwardfor
+balance roundrobin
+server second second:80 check port 80
+
+backend third_backend
+mode http
+option forwardfor
+balance roundrobin
+server third third:80 check port 80
+
+backend fourth_backend
+mode http
+option forwardfor
+balance roundrobin
+server fourth fourth:80 check port 80
+
+backend fifth_backend
+mode http
+option forwardfor
+balance roundrobin
+server fifth fifth:80 check port 80


### PR DESCRIPTION
Allows multiple config envvars to be specified to allow
the building of a valid config.

This allows very large configs to be split across envvars
to ensure that the kernel argument limit size (128K) is
not breached.

Connects-to: #31
Change-type: minor
Signed-off-by: Heds Simons <heds@balena.io>