### PR TITLE
frontend: Allow stats to be enabled on frontends

### DIFF
--- a/test/fixtures/cfg.json
+++ b/test/fixtures/cfg.json
@@ -368,5 +368,29 @@
             }
         ],
         "cli_timeout": "1h"
+    },
+    "stats": {
+        "frontend": [
+            {
+                "protocol": "https",
+                "domain": "*",
+                "port": "1936",
+                "stats": [
+                    "enable",
+                    "uri /https_route",
+                    "auth test:test"
+                ]
+            },
+            {
+                "protocol": "http",
+                "domain": "*",
+                "port": "1937",
+                "stats": [
+                    "enable",
+                    "uri /http_route"
+                ]
+            }
+        ],
+        "cli_timeout": "1h"
     }
 }

--- a/test/outputs/output-config
+++ b/test/outputs/output-config
@@ -15,6 +15,14 @@ reqadd X-Forwarded-Proto:\ http
 acl host_admin-http_backend hdr_dom(host) -i admin.open-balena-haproxy.local
 use_backend admin-http_backend if host_admin-http_backend
 
+frontend http_1937_in
+mode http
+option forwardfor
+bind *:1937
+reqadd X-Forwarded-Proto:\ http
+stats enable
+stats uri /http_route
+
 frontend https_443_in
 mode tcp
 bind *:443
@@ -78,6 +86,14 @@ reqadd X-Forwarded-Proto:\ https
 
 acl host_registry2-81_backend hdr_dom(host) -i registry2.open-balena-haproxy.local
 use_backend registry2-81_backend if host_registry2-81_backend
+
+frontend https_1936_in
+mode http
+bind *:1936 ssl crt {{tmp}}/chain.pem
+reqadd X-Forwarded-Proto:\ https
+stats enable
+stats uri /https_route
+stats auth test:test
 
 frontend tcp_222_in
 mode tcp


### PR DESCRIPTION
Also ensures that backends are not generated should
there not be a backend structure assigned to a group.

Connects-to: #35
Change-type: minor
Signed-off-by: Heds Simons <heds@balena.io>