### PR TITLE
resolvers: Allow resolver definitions for lookup

### DIFF
--- a/src/generate.ts
+++ b/src/generate.ts
@@ -99,7 +99,13 @@ capitano.command({
 				processConfig = process.env[`${envvar}_${configCounter++}`];
 			}
 
-			return GenerateHaproxyConfig(finalConfig, outputConfig, outputCert);
+			if (finalConfig) {
+				return GenerateHaproxyConfig(
+					finalConfig as Configuration,
+					outputConfig,
+					outputCert,
+				);
+			}
 		} else if (envvar) {
 			throw new Error('Could not find environment variable: ' + envvar);
 		} else {

--- a/test/fixtures/cfg.json
+++ b/test/fixtures/cfg.json
@@ -1,9 +1,29 @@
 {
+    "resolvers": [
+        {
+            "id": "test-bridge-resolver",
+            "nameservers": {
+                "test-dns-resolver": "127.0.0.11:53",
+                "second-dns-resolver": "17.18.0.1:1234"
+            },
+            "hold": {
+                "valid": "0ms",
+                "obsolete": "1000ms",
+                "refused": "30s"
+            },
+            "resolveRetries": "3",
+            "timeout": {
+                "resolve": "1s"
+            }
+        }
+    ],
     "admin-http": {
         "backend": [
             {
                 "url": "http://admin:80",
                 "server": {
+                    "resolvers": "test-bridge-resolver",
+                    "resolve-prefer": "ipv4",
                     "check": null,
                     "port": "<port>"
                 }
@@ -43,6 +63,8 @@
             {
                 "url": "http://api:80",
                 "server": {
+                    "resolvers": "test-bridge-resolver",
+                    "resolve-prefer": "ipv4",
                     "check": null,
                     "port": "<port>"
                 }
@@ -50,6 +72,8 @@
             {
                 "url": "http://api2:80",
                 "server": {
+                    "resolvers": "test-bridge-resolver",
+                    "resolve-prefer": "ipv4",
                     "check": null,
                     "port": "<port>"
                 }
@@ -309,8 +333,7 @@
                 "domain": "*",
                 "port": "222"
             }
-        ],
-        "cli_timeout": "1h"
+        ]
     },
     "git": {
         "backend": [
@@ -328,8 +351,7 @@
                 "domain": "*",
                 "port": "2222"
             }
-        ],
-        "cli_timeout": "1h"
+        ]
     },
     "db": {
         "backend": [
@@ -347,8 +369,7 @@
                 "domain": "*",
                 "port": "5432"
             }
-        ],
-        "cli_timeout": "1h"
+        ]
     },
     "redis": {
         "backend": [
@@ -364,10 +385,10 @@
             {
                 "protocol": "tcp",
                 "domain": "*",
-                "port": "6379"
+                "port": "6379",
+                "clientTimeout": "1h"
             }
-        ],
-        "cli_timeout": "1h"
+        ]
     },
     "stats": {
         "frontend": [
@@ -390,7 +411,6 @@
                     "uri /http_route"
                 ]
             }
-        ],
-        "cli_timeout": "1h"
+        ]
     }
 }

--- a/test/outputs/output-config
+++ b/test/outputs/output-config
@@ -6,6 +6,15 @@ timeout connect 5000
 timeout client 60000
 timeout server 60000
 
+resolvers test-bridge-resolver
+  nameserver test-dns-resolver 127.0.0.11:53
+  nameserver second-dns-resolver 17.18.0.1:1234
+  hold valid 0ms
+  hold obsolete 1000ms
+  hold refused 30s
+  resolve_retries 3
+  timeout resolve 1s
+
 frontend http_80_in
 mode http
 option forwardfor
@@ -114,12 +123,13 @@ frontend tcp_6379_in
 mode tcp
 bind *:6379
 default_backend redis_backend
+timeout client 1h
 
 backend admin-http_backend
 mode http
 option forwardfor
 balance roundrobin
-server admin admin:80 check port 80
+server admin admin:80 resolvers test-bridge-resolver resolve-prefer ipv4 check port 80
 
 backend admin_backend
 mode http
@@ -131,8 +141,8 @@ backend api_backend
 mode http
 option forwardfor
 balance roundrobin
-server api api:80 check port 80
-server api2 api2:80 check port 80
+server api api:80 resolvers test-bridge-resolver resolve-prefer ipv4 check port 80
+server api2 api2:80 resolvers test-bridge-resolver resolve-prefer ipv4 check port 80
 
 backend builder_backend
 mode http


### PR DESCRIPTION
This commit allows the definition of nameserver
resolvers to allow backends to be looked up based
upon specific parameters.

See the 'test/fixtures/cfg.json' file for an example
which is based upon HAProxy's standard settings.

Connects-to: #37
Change-type: minor
Signed-off-by: Heds Simons <heds@balena.io>