### PR TITLE
Fix error when frontend has no http protocol

### DIFF
--- a/src/generate-config.ts
+++ b/src/generate-config.ts
@@ -336,7 +336,9 @@ const generateTcpConfig = (
 	if (!_.get(configuration, ['frontend', 'https', port])) {
 		confStr +=
 			`\nfrontend tcp_${port}_in\n` + 'mode tcp\n' + `bind *:${port}\n`;
-		confStr += statsGenerator(configuration['frontend']['http'][port]);
+		if (_.has(configuration, ['frontend', 'http', port])) {
+			confStr += statsGenerator(configuration['frontend']['http'][port]);
+		}
 		_.forEach(configuration['frontend']['tcp'][port], acl => {
 			if (acl.backendName) {
 				confStr += `default_backend ${acl.backendName}\n`;


### PR DESCRIPTION
Change-type: patch

```
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]: TypeError: Cannot read property '5432' of undefined
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at generateTcpConfig (/usr/src/app/build/generate-config.js:97:68)
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at /usr/src/app/build/generate-config.js:273:44
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at /usr/src/app/node_modules/lodash/lodash.js:4911:15
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at baseForOwn (/usr/src/app/node_modules/lodash/lodash.js:2996:24)
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at /usr/src/app/node_modules/lodash/lodash.js:4880:18
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at Function.forEach (/usr/src/app/node_modules/lodash/lodash.js:9344:14)
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at /usr/src/app/build/generate-config.js:271:15
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at /usr/src/app/node_modules/lodash/lodash.js:4911:15
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at baseForOwn (/usr/src/app/node_modules/lodash/lodash.js:2996:24)
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at /usr/src/app/node_modules/lodash/lodash.js:4880:18
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at Function.forEach (/usr/src/app/node_modules/lodash/lodash.js:9344:14)
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at Object.<anonymous> (/usr/src/app/build/generate-config.js:270:11)
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at Generator.next (<anonymous>)
[Logs]    [1/24/2021, 3:51:55 AM] [haproxy] generate-config[62]:     at fulfilled (/usr/src/app/build/generate-config.js:4:58)
```