### PR TITLE
Adds device URL support

### DIFF
--- a/src/generate-config.ts
+++ b/src/generate-config.ts
@@ -373,6 +373,15 @@ const generateHttpConfig = (
 		'option forwardfor\n' +
 		`bind *:${port}\n` +
 		'reqadd X-Forwarded-Proto:\\ http\n';
+
+	// balena device URL v1 support
+	if (process.env.BALENA_DEVICE_UUID) {
+		confStr +=
+			'\n' +
+			'acl host_ui_backend_via_device_url hdr_reg(host) -i ^.*$\n' +
+			'use_backend ui_backend if host_ui_backend_via_device_url\n';
+	}
+
 	confStr += statsGenerator(configuration['frontend']['http'][port]);
 	_.forEach(configuration['frontend']['http'][port], acl => {
 		if (acl.backendName) {


### PR DESCRIPTION
* allows haproxy runnig on balena devices to accept wildcard hostheader on port 80 (via device URLs v1)

Change-type: patch