### PR TITLE
patch: ARM64 builds

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,6 @@
+target "default" {
+  platforms = [
+    "linux/amd64",
+    "linux/arm64"
+  ]
+}


### PR DESCRIPTION
> component currently AMD64 only

Required by:
* https://github.com/balena-io/balena-cloud/pull/6118

* https://balena.fibery.io/Security/Information_Security_and_Reliability_Incident/173
* https://balena.fibery.io/Work/Project/Capture-data-to-build-the-balena-reliability-pipeline-1422